### PR TITLE
Fix DELETE API to actually delete the element.

### DIFF
--- a/routes/api/members.js
+++ b/routes/api/members.js
@@ -56,12 +56,13 @@ router.put('/:id', (req, res) => {
 
 // Delete Member
 router.delete('/:id', (req, res) => {
-  const found = members.some(idFilter(req));
+  const foundIdx = members.findIndex(idFilter(req));
 
-  if (found) {
+  if (foundIdx !== -1) {
+    members.splice(foundIdx,1)
     res.json({
       msg: 'Member deleted',
-      members: members.filter(member => !idFilter(req)(member))
+      members
     });
   } else {
     res.status(400).json({ msg: `No member with the id of ${req.params.id}` });


### PR DESCRIPTION
The `/api/members/:id` `DELETE` request does not delete the member from the members array but rather just responding back with a copy of the members array with that member deleted.

The pull request only edits the `DELETE` API so that it actually deletes the member from the original array and responding back with the same array.